### PR TITLE
feat: Add buildkit container with exposed port

### DIFF
--- a/.github/workflows/buildkit-service.yaml
+++ b/.github/workflows/buildkit-service.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2024 Jonas Fierlings <fnoegip@gmail.com>
+#
+# SPDX-License-Identifier: 0BSD
+---
+name: Build the buildkit container
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/buildkit-service.yaml
+      - containers/buildkit-service.hcl
+      - docker-bake.hcl
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - .github/workflows/buildkit-service.yaml
+      - containers/buildkit-service.hcl
+      - docker-bake.hcl
+
+  merge_group:
+    paths:
+      - .github/workflows/buildkit-service.yaml
+      - containers/buildkit-service.hcl
+      - docker-bake.hcl
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.container }}
+  cancel-in-progress: true
+
+jobs:
+  build-buildkit:
+    runs-on: ubuntu-24.04
+    name: buildkit-service images
+    permissions:
+      contents: read # for actions/checkout
+      packages: write # for docker/bake-action
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Required to get the correct file modification date with `git log`
+          fetch-depth: "0"
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate docker metadata
+        id: docker-metadata
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          annotations: |
+            org.opencontainers.image.title=buildkit
+            org.opencontainers.image.description=concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+            org.opencontainers.image.source=https://github.com/moby/buildkit
+            org.opencontainers.image.licenses=Apache-2.0
+          bake-target: _docker-metadata-action
+      - name: Set SOURCE_DATE_EPOCH to git timestamp
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct ./containers/buildkit-service.hcl)" >> "$GITHUB_ENV"
+      - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'Push' || 'Build' }} the buildkit container
+        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/containers/buildkit
+        with:
+          files: |
+            ./docker-bake.hcl
+            ./containers/buildkit-service.hcl
+            ${{ steps.docker-metadata.outputs.bake-file-annotations }}
+          targets: buildkit-service
+          set: |
+            *.cache-from=type=gha,scope=buildkit
+            *.cache-to=type=gha,scope=buildkit,mode=max
+            *.output=type=image,rewrite-timestamp=true,oci-mediatypes=true,push=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -91,4 +91,4 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=${{ inputs.name }}
             *.cache-to=type=gha,scope=${{ inputs.name }},mode=max
-            *.output=type=image,rewrite-timestamp=true,push=${{ inputs.push }}
+            *.output=type=image,rewrite-timestamp=true,oci-mediatypes=true,push=${{ inputs.push }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # containers
 
-This repository provides [container image] builds of repositories that do not provide their own.
+This repository provides [container image] builds of repositories that do not provide their own,
+or slightly adjusted upstream images.
 The primary purpose is for use in [GitLab CI/CD],
 as well as for installation in other container images[^container-images-install].
 
@@ -18,10 +19,11 @@ as well as for installation in other container images[^container-images-install]
 
 ## Available Containers
 
-| Upstream Repository  | Container Image                                           | Architecture             |
-| -------------------- | --------------------------------------------------------- | ------------------------ |
-| [crate-ci/typos]     | [`ghcr.io/pigeonf/containers/typos:1.28.2`][typos]        | `amd64` [^crate-ci-arch] |
-| [crate-ci/committed] | [`ghcr.io/pigeonf/containers/committed:1.1.2`][committed] | `amd64` [^crate-ci-arch] |
+| Upstream Repository  | Container Image                                           | Architecture                                                                |
+| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [crate-ci/typos]     | [`ghcr.io/pigeonf/containers/typos:1.28.2`][typos]        | `amd64` [^crate-ci-arch]                                                    |
+| [crate-ci/committed] | [`ghcr.io/pigeonf/containers/committed:1.1.2`][committed] | `amd64` [^crate-ci-arch]                                                    |
+| [moby/buildkit]      | [`ghcr.io/pigeonf/containers/buildkit`][buildkit]         | `amd64`,  `arm/v7`, `arm64`, `s390x`, `ppc64le`, `riscv64` [^buildkit-arch] |
 
 [crate-ci/typos]: https://github.com/crate-ci/typos
 [typos]: https://github.com/PigeonF/containers/pkgs/container/containers%2Ftypos
@@ -33,6 +35,9 @@ as well as for installation in other container images[^container-images-install]
   If you have a need for additional architectures,
   feel free to [open a pull request],
   or [an issue].
+
+[^buildkit-arch]: &ZeroWidthSpace;
+  The same architectures as the upstream image.
 
 [open a pull request]: https://github.com/PigeonF/containers/pulls
 [an issue]: https://github.com/PigeonF/containers/issues

--- a/containers/buildkit-service.hcl
+++ b/containers/buildkit-service.hcl
@@ -29,26 +29,32 @@ target "buildkit-service" {
   matrix = {
     item = [
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "buildx-stable-1"
         digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
       },
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "buildx-stable-1-rootless"
         digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
       },
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "v0.18.1"
         digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
       },
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "v0.18.1-rootless"
         digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
       },
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "latest"
         digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
       },
       {
+        # renovate: depName=docker.io/moby/buildkit
         tag = "rootless"
         digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
       },

--- a/containers/buildkit-service.hcl
+++ b/containers/buildkit-service.hcl
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2024 Jonas Fierlings <fnoegip@gmail.com>
+#
+# SPDX-License-Identifier: 0BSD
+
+group "default" {
+  targets = ["buildkit-service"]
+}
+
+variable "IMAGE" {
+  default = "pigeonf/containers/buildkit"
+}
+
+variable "BUILDKIT_PORT" {
+  default = "3375"
+}
+
+target "buildkit-service" {
+  inherits = ["_common", "_docker-metadata-action"]
+  name = "buildkit-${replace(item.tag, ".", "-")}"
+  dockerfile-inline = <<EOT
+    FROM docker.io/moby/buildkit:${item.tag}@${item.digest}
+    EXPOSE ${BUILDKIT_PORT}
+    CMD ["--oci-worker-no-process-sandbox", "--addr", "tcp://:${BUILDKIT_PORT}"]
+  EOT
+  output = ["type=image,rewrite-timestamp=true,oci-mediatypes=true"]
+  tags = [
+    "${lower(IMAGE)}:${item.tag}"
+  ]
+  matrix = {
+    item = [
+      {
+        tag = "buildx-stable-1"
+        digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
+      },
+      {
+        tag = "buildx-stable-1-rootless"
+        digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
+      },
+      {
+        tag = "v0.18.1"
+        digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
+      },
+      {
+        tag = "v0.18.1-rootless"
+        digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
+      },
+      {
+        tag = "latest"
+        digest = "sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5"
+      },
+      {
+        tag = "rootless"
+        digest = "sha256:8e70f1e38c50ec5ac8e8fb861c837e9e7b2350ccb90b10e429733f8bda3b7809"
+      },
+    ]
+  }
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/s390x",
+    "linux/ppc64le",
+    "linux/riscv64",
+  ]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -38,7 +38,8 @@
       ],
       "matchStrings": [
         "\\s*default\\s?=\\s?\"(?<currentValue>.+?)\" # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s",
-        "\\s*default\\s?=\\s?\"(?<currentDigest>.+?)\" # renovate: currentValue=(?<currentValue>.+?) datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s"
+        "\\s*default\\s?=\\s?\"(?<currentDigest>.+?)\" # renovate: currentValue=(?<currentValue>.+?) datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s",
+        "# renovate: depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+tag\\s*=\\s*[\"'](?<currentValue>.+?)[\"']\\s(?:\\s*digest\\s*=\\s*[\"'](?<currentDigest>.+?)[\"']\\s)?"
       ]
     },
     {


### PR DESCRIPTION
This is useful for use in GitLab CI/CD, where services have to undergo a health check. Since the default buildkit image does not `EXPOSE` a port, the healthcheck will fail. This image is intended as a replacement: all it does is add the `EXPOSE` instruction and sets a default `CMD` that works in GitLab CI/CD.