### PR TITLE
chore(markdown): Use one line per sentence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,28 +8,14 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Thank you for considering to contribute to the project.
 
-The repository is for my personal use,
-but I am open to suggestion and extending the list of available container images,
-as well as the list of architectures for which the container images are built.
+The repository is for my personal use, but I am open to suggestion and extending the list of available container images, as well as the list of architectures for which the container images are built.
 
-For a high level overview of what aims this repository sets out to achieve,
-take a look at the [project's design considerations](./docs/README.md#project-design).
-If you are looking for an overview of the repository,
-consider the [description of the repository's layout](./docs/README.md#repository-layout).
-Before contributing,
-you might also want to take a look at the [development guide](./docs/developing.md).
+For a high level overview of what aims this repository sets out to achieve, take a look at the [project's design considerations](./docs/README.md#project-design).
+If you are looking for an overview of the repository, consider the [description of the repository's layout](./docs/README.md#repository-layout).
+Before contributing, you might also want to take a look at the [development guide](./docs/developing.md).
 
-Please note that if you contribute directly[^contribute-directly] to the repository,
-your contributions will be licensed [as described in the readme](./README.md#license),
-unless you explicitly state otherwise.
+Please note that if you contribute directly[^contribute-directly] to the repository, your contributions will be licensed [as described in the readme](./README.md#license), unless you explicitly state otherwise.
 
-[^contribute-directly]: &ZeroWidthSpace;
-That is,
-if you add commits to the repository,
-instead of,
-say,
-creating or triaging issues in the [issue tracker].
-
-[issue tracker]: https://github.com/PigeonF/containers/issues
+[^contribute-directly]: That is, if you add commits to the repository, instead of, say, creating or triaging issues in the [issue tracker](https://github.com/PigeonF/containers/issues).
 
 This project has adopted the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # containers
 
-This repository provides [container image] builds of repositories that do not provide their own,
-or slightly adjusted upstream images.
-The primary purpose is for use in [GitLab CI/CD],
-as well as for installation in other container images[^container-images-install].
+This repository provides [container image](https://opencontainers.org/) builds of repositories that do not provide their own, or slightly adjusted upstream images.
+The primary purpose is for use in [GitLab CI/CD](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html), as well as for installation in other container images[^container-images-install].
 
-[container image]: https://opencontainers.org/
-[GitLab CI/CD]: https://docs.gitlab.com/ee/ci/docker/using_docker_images.html
-[^container-images-install]: &ZeroWidthSpace;
-  The easiest way to install an application in a container image without a package manager,
-  is to copy the binary from a separate container image that already contains the binary.
+[^container-images-install]: The easiest way to install an application in a container image without a package manager, is to copy the binary from a separate container image that already contains the binary.
 
 ## Available Containers
 
@@ -32,38 +26,24 @@ as well as for installation in other container images[^container-images-install]
 [moby/buildkit]: https://github.com/moby/buildkit
 [buildkit]: https://github.com/PigeonF/containers/pkgs/container/containers%2Fbuildkit
 
-[^buildkit]: &ZeroWidthSpace;
-  This is a copy of the [upstream buildkit container],
-  but with an `EXPOSE` instruction so that the buildkit container can be used as a [GitLab CI/CD service].
+[^buildkit]: This is a copy of the [upstream buildkit container](https://hub.docker.com/r/moby/buildkit).
+  The only difference is an added `EXPOSE` instruction so that the buildkit container can be used as a [GitLab CI/CD service](https://docs.gitlab.com/ee/ci/services/).
 
-[upstream buildkit container]: https://hub.docker.com/r/moby/buildkit
-[GitLab CI/CD service]: https://docs.gitlab.com/ee/ci/services/
+[^buildkit-arch]: The same architectures as the upstream image.
 
-[^crate-ci-arch]: &ZeroWidthSpace;
-  This corresponds to the same architectures as the upstream prebuilt binaries for linux.
-  If you have a need for additional architectures,
-  feel free to [open a pull request],
-  or [an issue].
-
-[^buildkit-arch]: &ZeroWidthSpace;
-  The same architectures as the upstream image.
-
-[open a pull request]: https://github.com/PigeonF/containers/pulls
-[an issue]: https://github.com/PigeonF/containers/issues
+[^crate-ci-arch]: This corresponds to the same architectures as the upstream prebuilt binaries for linux.
+  If you have a need for additional architectures, feel free to [open a pull request](https://github.com/PigeonF/containers/pulls), or [an issue](https://github.com/PigeonF/containers/issues).
 
 ## Building
 
-To build a container you have to call `docker bake` with both [`docker-bake.hcl`],
-and the [container hcl file].
-For example,
-to build the `typos` container
-
-[`docker-bake.hcl`]: ./docker-bake.hcl
-[container hcl file]: ./containers/
+To build a container you have to call `docker bake` with both [`docker-bake.hcl`](./docker-bake.hcl), and the [container hcl file](./containers/).
+For example, to build the `typos` container
 
 ```console
 docker buildx bake -f docker-bake.hcl -f containers/typos.hcl
 ```
+
+For more detailed instructions, refer to the [developer documentation](./docs/developing.md).
 
 ## License
 
@@ -73,9 +53,7 @@ _This project is [REUSE] compliant_.
 
 Different parts of the work fall under different licenses[^license-summary]
 
-[^license-summary]: &ZeroWidthSpace;
-  The summary is for you to get a rough overview,
-  not to give a comprehensive listing.
+[^license-summary]: The summary is for you to get a rough overview, not to give a comprehensive listing.
 
 - Source code is dual licensed under `0BSD`.
 - Documentation is licensed under `CC-BY-4.0`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,81 +12,43 @@ SPDX-License-Identifier: CC-BY-4.0
 ## Project Goals
 
 The purpose of the repository is to provide easy access to tools that can be used in [GitLab CI/CD].
-The easiest way to do so is to provide a [docker image] that contains the desired tool(s).
-As some projects do not provide ready container images,
-or provides container images that need additional modifications to work with [GitLab CI/CD],
-this project provides them instead.
+The easiest way to do so is to provide a [docker image](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) that contains the desired tool(s).
+As some projects do not provide ready container images, or provides container images that need additional modifications to work with [GitLab CI/CD], this project provides them instead.
 
 [GitLab CI/CD]: https://docs.gitlab.com/ee/ci/
-[docker image]: https://docs.gitlab.com/ee/ci/docker/using_docker_images.html
 
 ## Project Design
 
-To ease maintenance of the repository,
-the container are images built from upstream [Dockerfile] definitions where possible.
-This is possible by using the upstream repositories as the [docker build context].
-
-[Dockerfile]: https://docs.docker.com/reference/dockerfile/
-[docker build context]: https://docs.docker.com/build/concepts/context/#remote-context
+To ease maintenance of the repository, the container are images built from upstream [Dockerfile](https://docs.docker.com/reference/dockerfile/) definitions where possible.
+This is possible by using the upstream repositories as the [docker build context](https://docs.docker.com/build/concepts/context/#remote-context).
 
 ## Repository Layout
 
-Two central parts of the repository are the [bake files][containers] and the [docker CI workflow].
-The former defines which containers to build (and how),
-whereas the latter is used for publishing the containers to [the project's container registry][container registry].
+Two central parts of the repository are the [bake files](../containers/) and the [docker CI workflow](../.github/workflows/docker.yaml).
+The former defines which containers to build (and how), whereas the latter is used for publishing the containers to [the project's container registry][container registry].
 
-[containers]: ../containers/
-[docker CI workflow]: ../.github/workflows/docker.yaml
 [container registry]: https://github.com/PigeonF?tab=packages&repo_name=containers
 
-- [**The `.github/` folder**][.github] contains the project's CI/CD configuration.
+- [**The `.github/` folder**](../.github/) contains the project's CI/CD configuration.
 
   The CI/CD configuration builds the containers during merge requests and merges to the `main` branch.
-  When a changed container configuration is merged into `main`,
-  the CI/CD configuration will automatically build and push the new container image to the [container registry].
+  When a changed container configuration is merged into `main`, the CI/CD configuration will automatically build and push the new container image to the [container registry].
 
-[.github]:  ../.github/
+- [**The `docker-bake.hcl` file**](../docker-bake.hcl) contains common configuration that is shared between all container definitions.
 
-- [**The `docker-bake.hcl` file**][bake file] contains common configuration that is shared between all container definitions.
+- [**The `containers/` folder**](../containers/) contains definitions on how to build the containers using `docker buildx bake`.
 
-[bake file]: ../docker-bake.hcl
+  - [**The `buildkit` container**](../containers/buildkit-service.hcl) modifies the [official container](hub.docker.com/r/moby/buildkit/) for <https://github.com/moby/buildkit>.
+    The goals is to ready the image for use as a [GitLab CI/CD service](https://docs.gitlab.com/ee/ci/services/).
 
-- [**The `containers/` folder**][containers] contains definitions on how to build the containers using `docker buildx bake`.
+  - [**The `committed` container**](../containers/committed.hcl) builds the <https://github.com/crate-ci/committed> git commit linter.
 
-  - [**The `buildkit` container**][buildkit] modifies the [official container][buildkit-container] for <https://github.com/moby/buildkit>,
-    so that it can be used as a [GitLab CI/CD service][gitlab-service]
+  - [**The `typos` container**](../containers/typos.hcl) builds the <https://github.com/crate-ci/typos> spell checker.
 
-  - [**The `committed` container**][committed] builds the <https://github.com/crate-ci/committed> git commit linter.
+- [**The `docs/` folder**](../docs/) contains project documentation.
 
-  - [**The `typos` container**][typos] builds the <https://github.com/crate-ci/typos> spell checker.
+- [**The `LICENSES/` folder**](../LICENSES/) contains a copy of the project's licenses.
 
-[buildkit]: ../containers/buildkit-service.hcl
-[buildkit-container]: hub.docker.com/r/moby/buildkit/
-[committed]: ../containers/committed.hcl
-[typos]: ../containers/typos.hcl
-[gitlab-service]: https://docs.gitlab.com/ee/ci/services/
+The remaining files (such as [`.editorconfig`](../.editorconfig), or [`renovate.json5`](../renovate.json5)) configuration files[^configuration-files], and are not overly important for the project itself.
 
-- [**The `docs/` folder**][docs] contains project documentation.
-
-[docs]: ../docs/
-
-- [**The `LICENSES/` folder**][LICENSES] contains a copy of the project's licenses.
-
-[LICENSES]: ../LICENSES/
-
-The remaining files
-(such as [`.editorconfig`], or [`renovate.json5`])
-are likely for configuring
-The remaining files are likely[^likely-files] configuration files,
-and are not overly important for the project.
-
-[`.editorconfig`]: ../.editorconfig
-[`renovate.json5`]: ../renovate.json5
-
-[^likely-files]: &ZeroWidthSpace;
-If you feel like one of these files should be mentioned in this document,
-feel free to [open an issue],
-or [create a pull request].
-
-[open an issue]: https://github.com/PigeonF/containers/issues
-[create a pull request]: https://github.com/PigeonF/containers/pulls
+[^configuration-files]: If you feel like one of these files should be mentioned in this document, feel free to [open an issue](https://github.com/PigeonF/containers/issues), or [add them in a pull request](https://github.com/PigeonF/containers/pulls).

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -6,51 +6,31 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Development Guide
 
-Before working on the project,
-please ensure that your editor is configured to follow the [EditorConfig] [configuration of the project].
+Before working on the project, please ensure that your editor is configured to follow the [EditorConfig](https://editorconfig.org) [configuration of the project](../.editorconfig).
 
-[EditorConfig]: https://editorconfig.org
-[configuration of the project]: ../.editorconfig
+To work on the project, you will need to install [docker](https://www.docker.com/).
+Other container engines are currently not supported, as I am not aware of any other [bake](https://docs.docker.com/build/bake/) implementations.
 
-To work on the project,
-you will need to install [docker].
-Other container engines are currently not supported,
-as I am not aware of any other [bake] implementations.
-
-[docker]: https://www.docker.com/
-[bake]: https://docs.docker.com/build/bake/
-
-Before hacking on the project,
-you might want to read the [high level project documentation](./README.md).
+Before hacking on the project, you might want to read the [high level project documentation](./README.md).
 
 ## Building
 
 Containers are built using `docker build bake`.
-The container definitions are split across multiple files,
-so that the [CI/CD configuration] can use fine grained checks to decide whether a container needs a rebuild.
-
-[CI/CD Configuration]: ../.github/workflows/
+The container definitions are split across multiple files, so that the [CI/CD configuration](../.github/workflows/) can use fine grained checks to decide whether a container needs a rebuild.
 
 The top level [`docker-bake.hcl`] contains definitions that are shared across all container definition files.
 
 [`docker-bake.hcl`]: ../docker-bake.hcl
 
-To build,
-pass both the [`docker-bake.hcl`] file,
-as well as the container definition file to `docker buildx bake`.
-For example,
-to build the [`typos`] container
-
-[`typos`]: ../containers/typos.hcl
+To build, pass both the [`docker-bake.hcl`] file, as well as the container definition file to `docker buildx bake`.
+For example, to build the [`typos`](../containers/typos.hcl) container
 
 ```console
 cd /path/to/repository/
 docker buildx bake -f docker-bake.hcl -f containers/typos.hcl
 ```
 
-To make use of the containers,
-load them into the docker daemon,
-or push them to a registry.
+To make use of the containers, load them into the docker daemon, or push them to a registry.
 
 ```console
 docker buildx bake -f docker-bake.hcl -f containers/typos.hcl --load

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -10,9 +10,7 @@ This guide is intended for maintainers of the project.
 
 ## Releasing a new version
 
-New versions of the containers are released automatically by the [CI/CD configuration] changes are merged into the `main` branch.
-
-[CI/CD configuration]: ../.github/workflows/
+New versions of the containers are released automatically by the [CI/CD configuration](../.github/workflows/) changes are merged into the `main` branch.
 
 ## CI/CD Secrets
 
@@ -26,6 +24,4 @@ The repository has bot account members to automate some tasks.
 
 This bot automatically updates dependencies.
 In this case this means updating the container dependencies to their latest released versions.
-The bot is configured via the [`renovate.json5`] file.
-
-[`renovate.json5`]: ../renovate.json5
+The bot is configured via the [`renovate.json5`](../renovate.json5) file.


### PR DESCRIPTION
To make the "style" "reproducible", there are two ways I can think of that do not depend on "vibes": always wrap at 80/100/120 columns, or one sentence per line. I think the one sentence per line style is diff-friendlier (and it encourages you to write shorter, i.e. more readable, sentences).